### PR TITLE
Remove default `.once` in singular matchers

### DIFF
--- a/lib/rspec/sidekiq_pro/matchers.rb
+++ b/lib/rspec/sidekiq_pro/matchers.rb
@@ -18,12 +18,10 @@ module RSpec
       # expect(AwesomeWorker).to have_enqueued_sidekiq_job.in(5.minutes)
       #
       def have_enqueued_sidekiq_job
-        HaveEnqueuedSidekiqJobs.new.once
-      end
-
-      def have_enqueued_sidekiq_jobs
         HaveEnqueuedSidekiqJobs.new
       end
+
+      alias_method :have_enqueued_sidekiq_jobs, :have_enqueued_sidekiq_job
 
       # Checks if a certain job was enqueued in a block.
       #
@@ -37,12 +35,10 @@ module RSpec
       #   .to enqueue_sidekiq_job(AwesomeWorker).in(5.minutes)
       #
       def enqueue_sidekiq_job(worker_class)
-        EnqueueSidekiqJobs.new(worker_class).once
-      end
-
-      def enqueue_sidekiq_jobs(worker_class)
         EnqueueSidekiqJobs.new(worker_class)
       end
+
+      alias_method :enqueue_sidekiq_jobs, :enqueue_sidekiq_job
     end
   end
 end

--- a/rspec-sidekiq_pro.gemspec
+++ b/rspec-sidekiq_pro.gemspec
@@ -12,7 +12,8 @@ Gem::Specification.new do |s|
 
   s.homepage = "http://github.com/inkstak/rspec-sidekiq_pro"
   s.licenses = ["MIT"]
-  s.summary = "A collection of tools and matchers for Sidekiq Pro"
+  s.summary = "A collection of RSpec matchers for Sidekiq Pro"
+  s.description = "A collection of RSpec matchers for Sidekiq Pro"
 
   s.files = Dir["lib/**/*"] + %w[LICENSE README.md]
   s.require_paths = ["lib"]


### PR DESCRIPTION
## The previous situation 

Implicitely, both matchers `enqueue_sidekiq_job` and `have_enqueued_sidekiq_job` matched that exactly only one job was enqueued.

```ruby
it "asserts that only job has been enqueued" do
  expect {
    SampleJob.perform_async
  }.to enqueue_sidekiq_job(SampleJob)
end
```

A plural (and undocumented) version of both matchers was available to not care about of how many jobs were enqueued.

```ruby
it "asserts that at least one jobs has been enqueued" do
  expect {
    SampleJob.perform_async
    SampleJob.perform_async
  }.to enqueue_sidekiq_jobs(SampleJob)
end
```

## The problem

Using this singular matcher may be confusing, especially when using negative assertions:

```ruby
it "succeed, but it smells like a false positive" do
  expect {
    SampleJob.perform_async
    SampleJob.perform_async
  }.not_to enqueue_sidekiq_job(SampleJob)
end
```

## The solution

The implicit `.once` option will be removed. Both singular and plural matchers are now aliased.
If you want to verify that only one and exactly only one job has been enqueued, you have to do it explicitely :

```ruby
it do
  expect {
    SampleJob.perform_async
  }.to enqueue_sidekiq_job(SampleJob).once
end

it do
  expect {
    SampleJob.perform_async
    SampleJob.perform_async
  }.not_to enqueue_sidekiq_job(SampleJob).once
end
```

This solution should not break existing specs, except ambiguous negative assertions.

